### PR TITLE
programmer: sdk: reduce the number of calibration pulses

### DIFF
--- a/programmer/nrf-fw/scum-programmer.c
+++ b/programmer/nrf-fw/scum-programmer.c
@@ -27,7 +27,7 @@ SCuM programmer.
 #define CALIBRATION_PULSE_WIDTH         50      // approximate duty cycle (out of 100)
 #define CALIBRATION_PERIOD              100     // period in ms
 #define CALIBRATION_FUDGE               308     // # of clock cycles of "fudge"
-#define CALIBRATION_NUMBER_OF_PULSES    25      // # of rising edges at 100ms
+#define CALIBRATION_NUMBER_OF_PULSES    10      // # of rising edges at 100ms
 
 #define PROGRAMMER_VDDD_HI_PIN          27UL
 #define PROGRAMMER_VDDD_LO_PIN          15UL

--- a/sdk/bsp/optical.c
+++ b/sdk/bsp/optical.c
@@ -243,7 +243,7 @@ void OPTICAL_SFD_Handler(void) {
         count_IF, IF_fine
     );
 
-    if (optical_vars.optical_cal_iteration == 25) {
+    if (optical_vars.optical_cal_iteration == 10) {
 
         // Disable this ISR
         NVIC_DisableIRQ(EXT_GPIO8_ACTIVEHIGH_IRQn);


### PR DESCRIPTION
This is a little optimization to reduce a little the programming time: it takes 1.6s for a 8KiB firmware, instead of 3.5s before)